### PR TITLE
readme: add a vscodium note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Plugin for scripting language [daScript](https://dascript.org/)
 - Download daScript from github repository [GaijinEntertainment/daScript](https://github.com/GaijinEntertainment/daScript)
 - Set path to compiler in daScript settings section
 
+> Note for VSCodium users: you might need to install the plugin's dependencies manually when installing it from VSIX (e.g. [dascript](https://marketplace.visualstudio.com/items?itemName=eguskov.dascript) extension).
+
 ## Features
 
 - Debugger


### PR DESCRIPTION
An optional hint to save someone time when trying to install the daslang language support.

I am not 100% sure it's a worthwhile addition, but some VSCodium users (like me) might not be too aware about the dependencies issue with VSIX installations. In fact, this is my first time facing it as most language support plugins were self-contained (or maybe VSIX distributions/installation routines changed).