### PR TITLE
Fix compatibility with daScript 0.6 (no more builtin das)

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,7 +5,8 @@
 		"lib": ["es2020"],
 		"outDir": "out",
 		"rootDir": "src",
-		"sourceMap": true
+		"sourceMap": true,
+		"skipLibCheck": true
 	},
 	"include": ["src"],
 	"exclude": ["node_modules", ".vscode-test"]

--- a/scripts/gen_tokens.das
+++ b/scripts/gen_tokens.das
@@ -1,7 +1,7 @@
 options gen2
 options indenting = 4
-require fio
-require strings
+require daslib/fio
+require daslib/strings
 require daslib/strings_boost
 
 variant Tokens {

--- a/server/completion_boost.das
+++ b/server/completion_boost.das
@@ -8,10 +8,10 @@ options no_unused_block_arguments
 options strict_smart_pointers
 options no_aot
 
-require ast
-require rtti
-require math
-require strings
+require daslib/ast
+require daslib/rtti
+require daslib/math
+require daslib/strings
 require daslib/strings_boost
 
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -7,6 +7,7 @@
 		"rootDir": "src",
 		"sourceMap": true,
 		"strictNullChecks": false,
+		"skipLibCheck": true,
 	},
 	"include": ["src"],
 	"exclude": ["node_modules"]

--- a/server/validate_file.das
+++ b/server/validate_file.das
@@ -8,10 +8,10 @@ options no_unused_block_arguments
 options strict_smart_pointers
 options no_aot
 
-require ast
-require rtti
-require strings
-require fio
+require daslib/ast
+require daslib/rtti
+require daslib/strings
+require daslib/fio
 require daslib/ast_boost
 require daslib/strings_boost
 require daslib/das_source_formatter


### PR DESCRIPTION
## Summary
- Update bare `require fio`, `require rtti`, `require ast` to `require daslib/fio`, `require daslib/rtti`, `require daslib/ast` for compatibility with daScript 0.6 (PR GaijinEntertainment/daScript#2304 moved builtin `.das` files to `daslib/`)
- Fix TypeScript build by adding `skipLibCheck: true` to client and server tsconfigs (pre-existing `vscode-jsonrpc` type incompatibility with newer TypeScript)

## Test plan
- [x] VSIX builds successfully
- [x] `.das` files compile with daScript 0.6
