### PR TITLE
Fix smart_ptr -> regular ptr migration for daScript 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dascript-plugin",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dascript-plugin",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "daScript language support",
 	"author": "Dmitri Granetchi",
 	"license": "MIT",
-	"version": "1.3.0",
+	"version": "1.3.2",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/profelis/daScript-plugin"

--- a/scripts/gen_tokens.das
+++ b/scripts/gen_tokens.das
@@ -29,24 +29,33 @@ def buildString(data : array<string>; prefix, postfix, decorator, delimeter : st
     if (length(data) == 0) {
         return prefix + postfix
     } else {
-        var res = ""
-        var line = prefix
-        for (i in iter_range(data)) {
-            let it = data[i]
-            if (length(line) + length(delimeter) + 2 * length(decorator) >= maxLen) {
-                res += (length(res) > 0 ? "\n" : "") + line
-                line = repeat(" ", prefix |> length())
+        let padStr = repeat(" ", length(prefix))
+        return build_string() $(var writer) {
+            var lineLen = length(prefix)
+            var isFirst = true
+            write(writer, prefix)
+            for (i in iter_range(data)) {
+                let it = data[i]
+                if (lineLen + length(delimeter) + 2 * length(decorator) >= maxLen) {
+                    if (!isFirst) {
+                        write(writer, "\n")
+                    }
+                    isFirst = false
+                    write(writer, padStr)
+                    lineLen = length(padStr)
+                }
+                write(writer, decorator)
+                write(writer, it)
+                write(writer, decorator)
+                lineLen += 2 * length(decorator) + length(it)
+                if (i < length(data) - 1) {
+                    write(writer, delimeter)
+                    lineLen += length(delimeter)
+                }
             }
-            line += "{decorator}{it}{decorator}"
-            if (i < length(data) - 1) {
-                line += delimeter
-            }
+            write(writer, postfix)
+            write(writer, "\n")
         }
-        if (length(line) > 0) {
-            res += "\n{line}"
-        }
-        res += postfix + "\n"
-        return res
     }
 }
 
@@ -65,7 +74,7 @@ def getOperators() {
 def getTokens(from : string) : Tokens {
     let path = get_das_root() + "/src/parser/ds_parser.ypp"
     var res <- Tokens(status = false)
-    fio::fopen(path, "rb") <| $(f) {
+    fio::fopen(path, "rb") $(f) {
         if (f == null) {
             debug("error: can't open {path}")
             return

--- a/server/completion_boost.das
+++ b/server/completion_boost.das
@@ -66,7 +66,7 @@ def fill_at(var res : CompletionAt&; at : LineInfo) {
 def BaseTypeString(t : rtti::Type) : string {
     let res = "{t}"
     if (length(res) > 1) {
-        let secondChar = res.slice(1,2)
+        let secondChar = res.slice(1, 2)
         let lowSecondChar = to_lower(secondChar)
         if (lowSecondChar != secondChar) {
             return "{lowSecondChar}{res.slice(2)}"
@@ -91,7 +91,7 @@ struct CompletionEnum : CompletionAt {
     @optional values : array<CompletionEnumValue>
 }
 
-def parse_enum(var res : CompletionContext; e : smart_ptr<Enumeration>&) {
+def parse_enum(var res : CompletionContext; e : Enumeration?) {
     var en <- CompletionEnum(name = "{e.name}", cpp = "{e.cppName}", baseType = BaseTypeString(e.baseType))
     en |> fill_at(e.at)
     if (e._module != null && length(e._module.name) > 0) {
@@ -120,7 +120,7 @@ struct CompletionGlobal : CompletionAt {
     @optional isUnused : bool
 }
 
-def parse_global(var res : CompletionContext; g : smart_ptr<ast::Variable>&) {
+def parse_global(var res : CompletionContext; g : Variable?) {
     var gl <- CompletionGlobal(name = "{g.name}")
     gl |> fill_at(g.at)
     if (g._module != null) {
@@ -160,15 +160,7 @@ struct CompletionStruct : CompletionAt {
     @optional gen : bool
 }
 
-def resolve_str(var s : smart_ptr<Structure>&) : Structure? {
-    return s |> get_ptr()
-}
-
-def resolve_str(var s : Structure?) : Structure? {
-    return s
-}
-
-def parse_struct(var res : CompletionContext; var s : smart_ptr<Structure>& | Structure?) {
+def parse_struct(var res : CompletionContext; s : Structure?) {
     var st <- CompletionStruct(name = "{s.name}")
     st |> fill_at(s.at)
     if (s._module != null) {
@@ -184,7 +176,6 @@ def parse_struct(var res : CompletionContext; var s : smart_ptr<Structure>& | St
         st.parentName = s.parent.name |> string()
         st.parentMod = s.parent._module != null ? "{s.parent._module.name}" : ""
     }
-    var sptr = s |> resolve_str()
     for (f in s.fields) {
         var field <- CompletionStructField(name = "{f.name}")
         field |> fill_at(f.at)
@@ -206,13 +197,13 @@ def private cleanupTDK(str : string) : string {
     var parts <- str |> split("const?")
 
     for (res in parts) {
-        res = replace_multiple(res, [ (" ==const", ""), (" const", ""), (" implicit", ""), (";", ",") ])
+        res = replace_multiple(res, [ (text = " ==const", replacement = ""), (text = " const", replacement = ""), (text = " implicit", replacement = ""), (text = ";", replacement = ",") ])
     }
 
     return parts |> join("const?")
 }
 
-def TypeDeclKey(t : smart_ptr<ast::TypeDecl>&) : string {
+def TypeDeclKey(t : TypeDecl?) : string {
     return t |> describe_typedecl(false, false, true) |> cleanupTDK()
 }
 
@@ -242,7 +233,7 @@ struct CompletionTypeDecl : CompletionAt {
 let skipTypeDescSize = fixed_array(Type.none, Type.autoinfer, Type.alias, Type.fakeLineInfo,
     Type.fakeContext, Type.alias, Type.typeDecl, Type.typeMacro, Type.option)
 
-def parse_typedecl(var res : CompletionContext; tdk : string; t : smart_ptr<TypeDecl>&; is_generic : bool) : void {
+def parse_typedecl(var res : CompletionContext; tdk : string; t : TypeDecl?; is_generic : bool) : void {
     let tdkHash = hash(tdk)
     if (res.typeDecls.key_exists(tdkHash)) {
         return
@@ -256,6 +247,7 @@ def parse_typedecl(var res : CompletionContext; tdk : string; t : smart_ptr<Type
     td.canMove = t.canMove
     td.canClone = t.canClone
     let totalArgs = min(length(t.argNames), length(t.argTypes))
+    td.fields |> reserve(max(length(t.argNames), length(t.argTypes)))
     for (idx, argN, argT in count(), t.argNames, t.argTypes) {
         var tf <- CompletionTypeDeclField(name = length(argN) > 0 ? "{argN}" : "_{idx}")
         tf.tdk = TypeDeclKey(argT)
@@ -303,7 +295,7 @@ def parse_typedecl(var res : CompletionContext; tdk : string; t : smart_ptr<Type
         td.tdk1 = TypeDeclKey(t.firstType)
         res |> parse_typedecl(td.tdk1, t.firstType, is_generic)
     } elif (length(t.dim) > 0) {
-        var inscope sub <- t |> clone_type()
+        var sub = clone_type(t)
         sub.dim |> pop()
         parse_typedecl(res, TypeDeclKey(sub), sub, is_generic)
         td.tdk1 = TypeDeclKey(sub)
@@ -324,7 +316,7 @@ struct CompletionTypeDef : CompletionAt {
     tdk : string
 }
 
-def parse_typedef(var res : CompletionContext; mod : Module?; n : string#; t : smart_ptr<TypeDecl>&) {
+def parse_typedef(var res : CompletionContext; mod : Module?; n : string#; t : TypeDecl?) {
     var td <- CompletionTypeDef(name = "{n}")
     td |> fill_at(t.at)
     td.mod = mod.name |> string()
@@ -367,7 +359,7 @@ def remove_fn_generation(name : string) : string {
     if (lastAt == -1) {
         return name
     }
-    for (i in lastAt+1..length(name)) {
+    for (i in lastAt + 1..length(name)) {
         if (!is_number(unsafe(character_uat(name, i)))) {
             return name
         }
@@ -391,7 +383,7 @@ def fix_fn_name(name : string) : string {
 }
 
 
-def parse_function(var res : CompletionContext; f : smart_ptr<Function>&; cpp : string; is_generic : bool) {
+def parse_function(var res : CompletionContext; f : Function?; cpp : string; is_generic : bool) {
     var fn <- CompletionFunction(name = "{f.name}", cpp = "{cpp}")
     fn.name = fix_fn_name(fn.name)
     fn.isGeneric = is_generic
@@ -440,7 +432,7 @@ def parse_annotation(var res : CompletionContext; ann : Annotation&) {
         if (ann._module != null) {
             st.mod = ann._module.name |> string()
         }
-        for_each_field(sann) <| $ [unused_argument(cppName)] (name, cppName, xtype, offset) {
+        for_each_field(sann) $ [unused_argument(cppName)] (name, cppName, xtype, offset) {
             var field <- CompletionStructField(name = "{name}")
             field.tdk = TypeDeclKey(xtype)
             res |> parse_typedecl(field.tdk, xtype, /*is_generic*/false)
@@ -469,41 +461,41 @@ def parse_annotation(var res : CompletionContext; ann : Annotation&) {
 def parse_module(var res : CompletionContext; mod : rtti::Module?) {
     // debug(mod)
 
-    mod |> for_each_enumeration() <| $(e) {
+    mod |> for_each_enumeration() $(e) {
         // debug(e)
         res |> parse_enum(e)
     }
 
-    mod |> for_each_global() <| $(g) {
+    mod |> for_each_global() $(g) {
         // debug(g)
         res |> parse_global(g)
     }
 
-    mod |> for_each_structure() <| $(s) {
+    mod |> for_each_structure() $(s) {
         res |> parse_struct(s)
     }
 
-    mod |> for_each_typedef() <| $(n, t) {
+    mod |> for_each_typedef() $(n, t) {
         // debug(t)
         res |> parse_typedef(mod, n, t)
     }
 
     var inscope funcCppNames : table<string; string>
-    mod |> module_for_each_function() <| $(f) {
+    mod |> module_for_each_function() $(f) {
         funcCppNames |> insert(f.name, clone_string(f.cppName))
     }
 
-    mod |> for_each_generic() <| $(f) {
+    mod |> for_each_generic() $(f) {
         // debug(f)
         res |> parse_function(f, funcCppNames?[string(f.name)] ?? "", true)
     }
 
-    mod |> for_each_function("") <| $(f) {
+    mod |> for_each_function("") $(f) {
         // debug(f)
         res |> parse_function(f, funcCppNames?[string(f.name)] ?? "", false)
     }
 
-    mod |> module_for_each_annotation() <| $(a) {
+    mod |> module_for_each_annotation() $(a) {
         res |> parse_annotation(a)
     }
 }

--- a/server/validate_file.das
+++ b/server/validate_file.das
@@ -94,7 +94,7 @@ def main() {
     if (WRITE_RESULT_TO_FILE) {
         mkdir("results")
         let fileName = file_name_to_uri(config.originalFile) |> split("/") |> back()
-        fopen("results/{fileName}.json", "w") <| $(f) {
+        fopen("results/{fileName}.json", "w") $(f) {
             if (f == null) {
                 error("unable to open file 'results/{fileName}.json'")
                 unsafe(fio::exit(1))
@@ -104,7 +104,7 @@ def main() {
     }
 
     if (WRITE_RESULT) {
-        fopen(config.resultFile, "w") <| $(f) {
+        fopen(config.resultFile, "w") $(f) {
             if (f == null) {
                 error("unable to open file '{config.resultFile}'")
                 unsafe(fio::exit(1))
@@ -161,12 +161,12 @@ struct ErrorData {
 
 def compile(var res : ValidationResult; config : ValidateConfig) {
 
-    fopen(config.file, "rb") <| $(fr) {
+    fopen(config.file, "rb") $(fr) {
         if (fr == null) {
             res.errors |> emplace(DasError(what = "unable to open file '{config.file}'"))
             return
         }
-        fmap(fr) <| $(fileCont) {
+        fmap(fr) $(fileCont) {
 
             if (config.autoFormat) {
                 res.autoFormat = das_source_formatter::format_source(fileCont)
@@ -177,7 +177,7 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
             access |> set_file_source(config.originalFile, string(fileCont))
             access |> init_file_access(config.fileAccessRoots)
 
-            using() <| $(var mg : ModuleGroup) {
+            using() $(var mg : ModuleGroup) {
                 var cp = CodeOfPolicies()
                 cp.no_global_variables = config.noGlobalVariables
                 cp.no_unused_block_arguments = config.noUnusedBlockArguments
@@ -190,13 +190,13 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
                 cp.max_infer_passes = config.maxInferPasses
                 if (typeinfo has_field<temp_one_liner_warning>(cp)) {
                     cp.temp_one_liner_warning = false
-                } 
+                }
                 cp.export_all = true
                 cp.aot_module = true
                 cp.completion = true
                 cp.no_optimizations = true
                 try {
-                    compile_file(config.originalFile, access, unsafe(addr(mg)), cp) <| $(ok, program, error) {
+                    compile_file(config.originalFile, access, unsafe(addr(mg)), cp) $(ok, program, error) {
 
 
                         if (ok && program != null) {
@@ -204,7 +204,7 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
 
                             var allDeps : table<uint64>
 
-                            program |> for_each_require_declaration() <| $(mod, name, file, isPublic, at) {
+                            program |> for_each_require_declaration() $(mod, name, file, isPublic, at) {
                                 var modReq <- ModuleRequirement(
                                     mod = mod != null ? "{mod.name}" : "",
                                     req = "{name}",
@@ -217,17 +217,17 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
                                     var allMods : table<uint64>
                                     var mods : array<tuple<mod : Module?; depth : int>>
                                     allMods |> insert(intptr(mod))
-                                    mods |> push((mod, 0))  // root dep is public for local module
+                                    mods |> push((mod = mod, depth = 0))  // root dep is public for local module
                                     while (length(mods) > 0) {
                                         var mod2 = mods |> back()
                                         mods |> pop()
-                                        mod2.mod |> module_for_each_dependency() <| $(dep, isPublic2) {
+                                        mod2.mod |> module_for_each_dependency() $(dep, isPublic2) {
                                             return if (!isPublic2 || dep == null)
 
                                             modReq.dependencies |> emplace(ModDeps(mod = "{dep.name}", depth = mod2.depth + 1))
                                             allDeps |> insert(intptr(dep))
                                             if (!allMods |> key_exists(intptr(dep))) {
-                                                mods |> push((dep, mod2.depth + 1))
+                                                mods |> push((mod = dep, depth = mod2.depth + 1))
                                                 allMods |> insert(intptr(dep))
                                             }
                                         }
@@ -252,7 +252,7 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
 
                             // else
 
-                            program_for_each_registered_module() <| $(mod) {
+                            program_for_each_registered_module() $(mod) {
                                 if (mod |> is_builtin()) {
                                     res.builtinMods |> push("{mod.name}")
                                 }
@@ -260,7 +260,7 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
 
                             var processed : table<string>
                             if (true) {
-                                program |> get_ptr() |> for_each_module() <| $(mod) {
+                                program |> get_ptr() |> for_each_module() $(mod) {
                                     // res.progMods |> push("{mod.name}")
                                     // global completion now contains only $(builtin) module
                                     if (config.globalCompletion && mod.name != "$") {
@@ -282,8 +282,9 @@ def compile(var res : ValidationResult; config : ValidateConfig) {
                             var visitor <- new AstData()
                             visitor.res = unsafe(addr(res))
                             visitor.completion = unsafe(addr(completion))
-                            var inscope adapter <- make_visitor(*visitor)
-                            program.visit_modules(adapter)
+                            make_visitor(*visitor) $(adapter) {
+                                visit_modules(program, adapter)
+                            }
                             unsafe {
                                 delete visitor
                             }
@@ -400,8 +401,6 @@ class AstData : AstVisitor {
         token |> fill_at(str.at)
         res.tokens |> emplace(token)
 
-        let stName = str._module != null ? "{str._module.name}::{str.name}" : "{str.name}"
-
         var inscope fields : table<string>
         var parent = str.parent
         while (parent != null) {
@@ -428,7 +427,7 @@ class AstData : AstVisitor {
     }
 
 
-    [unused_argument(index, last)] def override preVisitExprMakeStructField(expr : smart_ptr<ExprMakeStruct>; index : int; decl : MakeFieldDeclPtr; last : bool) : void {
+    [unused_argument(index, last)] def override preVisitExprMakeStructField(expr : ExprMakeStruct ?; index : int; decl : MakeFieldDeclPtr; last : bool) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
@@ -489,12 +488,12 @@ class AstData : AstVisitor {
 
     [unused_argument(name)] def override visitAlias(var typ : TypeDeclPtr; name : das_string) : TypeDeclPtr {
         ignoreNextTypeDecl = false
-        return <- typ
+        return typ
     }
 
 
     def override preVisitExpression(expr : ExpressionPtr) : void {
-        let ptr = intptr(expr |> get_ptr())
+        let ptr = intptr(expr)
         if (key_exists(visitedExprs, ptr)) {
             return
         }
@@ -612,14 +611,14 @@ class AstData : AstVisitor {
         res.tokens |> emplace(token)
     }
 
-    def override preVisitExprCall(expr : smart_ptr<ExprCall>) : void {
+    def override preVisitExprCall(expr : ExprCall?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
-        preVisitExprCallFunc(expr |> get_ptr())
+        preVisitExprCallFunc(expr)
     }
 
-    def override preVisitExprLet(expr : smart_ptr<ExprLet>) : void {
+    def override preVisitExprLet(expr : ExprLet?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
@@ -642,7 +641,7 @@ class AstData : AstVisitor {
         }
     }
 
-    [unused_argument(last)] def override preVisitExprForVariable(expr : smart_ptr<ExprFor>; svar : VariablePtr; last : bool) : void {
+    [unused_argument(last)] def override preVisitExprForVariable(expr : ExprFor ?; svar : VariablePtr; last : bool) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated || svar.flags.generated) {
             return
         }
@@ -664,7 +663,7 @@ class AstData : AstVisitor {
     }
 
 
-    def override preVisitExprVar(expr : smart_ptr<ExprVar>) : void {
+    def override preVisitExprVar(expr : ExprVar?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
@@ -791,10 +790,10 @@ class AstData : AstVisitor {
                 skipExprs |> pop()
             }
         }
-        return <- fun
+        return fun
     }
 
-    [unused_argument(lastArg)] def override preVisitExprBlockArgument(blk : smart_ptr<ExprBlock>; arg : VariablePtr; lastArg : bool) : void {
+    [unused_argument(lastArg)] def override preVisitExprBlockArgument(blk : ExprBlock ?; arg : VariablePtr; lastArg : bool) : void {
         if (length(skipExprs) > 0 || blk == null || blk.genFlags.generated || arg.flags.generated) {
             return
         }
@@ -817,18 +816,18 @@ class AstData : AstVisitor {
         res.tokens |> emplace(token)
     }
 
-    def override preVisitExprOp1(expr : smart_ptr<ExprOp1>) : void {
+    def override preVisitExprOp1(expr : ExprOp1?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
-        preVisitExprCallFunc(expr |> get_ptr())
+        preVisitExprCallFunc(expr)
     }
 
-    def override preVisitExprOp2(expr : smart_ptr<ExprOp2>) : void {
+    def override preVisitExprOp2(expr : ExprOp2?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
-        preVisitExprCallFunc(expr |> get_ptr())
+        preVisitExprCallFunc(expr)
     }
 
     // def override preVisitExprTypeInfo(expr : smart_ptr<ExprTypeInfo>) : void
@@ -873,7 +872,7 @@ class AstData : AstVisitor {
     // - functions
     // - operators (Op1, Op2)
 
-    def override preVisitExprAssume(expr : smart_ptr<ExprAssume>) : void {
+    def override preVisitExprAssume(expr : ExprAssume?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
@@ -893,7 +892,7 @@ class AstData : AstVisitor {
         res.tokens |> emplace(token)
     }
 
-    def override preVisitExprMakeStruct(expr : smart_ptr<ExprMakeStruct>) {
+    def override preVisitExprMakeStruct(expr : ExprMakeStruct?) {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }
@@ -905,7 +904,7 @@ class AstData : AstVisitor {
         res.tokens |> emplace(token)
     }
 
-    def override preVisitExprConstBitfield(expr : smart_ptr<ExprConstBitfield>) : void {
+    def override preVisitExprConstBitfield(expr : ExprConstBitfield?) : void {
         if (length(skipExprs) > 0 || expr == null || expr.genFlags.generated) {
             return
         }


### PR DESCRIPTION
## Summary

- **completion_boost.das**: Replace `smart_ptr<T>&` with `T?` for all AST types (Enumeration, Variable, Structure, TypeDecl, Function), remove `resolve_str` overloads, fix `clone_type` usage. Update `replace_multiple` call to use named tuple fields (`text`/`replacement`) — daScript now requires named-field literals when the target tuple type declares names.
- **validate_file.das**: Update visitor overrides from `smart_ptr<ExprXxx>` to `ExprXxx?`, fix `make_visitor` to use block callback pattern, remove `get_ptr()` on raw pointers, fix return semantics for FunctionPtr/TypeDeclPtr. Update module-dependency `push((mod, depth))` calls to use named tuple fields.
- Fix all lint warnings (PERF001/006, STYLE001, LINT002)
- Run formatter on all `.das` files
- Bump version to 1.3.2

## Test plan

- [x] All `.das` files compile cleanly with `daslang.exe -compile-only`
- [x] Lint passes with 0 issues on all files
- [x] VSIX builds successfully (`dascript-plugin-1.3.2.vsix`)